### PR TITLE
Updated access of ofVideoGrabber width.

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -46,7 +46,7 @@ public:
 	{
 		video.draw(0, 0);
 		gui.draw();
-		ofTranslate(video.width, 0);
+		ofTranslate(video.getWidth(), 0);
 		evm.draw();
 	}
 	void updateParams()


### PR DESCRIPTION
Directly accessing the width property of ofVideoGrabber is causing errors on both Mac OS X and Ubuntu. I updated it with a call to getWidth.